### PR TITLE
Add Kubernetes infrastructure Helm chart and Argo CD applications

### DIFF
--- a/infra/argocd/app-cert-manager.yaml
+++ b/infra/argocd/app-cert-manager.yaml
@@ -1,0 +1,24 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: cert-manager
+  namespace: argocd
+spec:
+  project: default
+  source:
+    repoURL: https://charts.jetstack.io
+    chart: cert-manager
+    targetRevision: v1.18.2
+    helm:
+      values: |
+        crds:
+          enabled: true
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: cert-manager
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true

--- a/infra/argocd/app-nginx.yaml
+++ b/infra/argocd/app-nginx.yaml
@@ -1,0 +1,25 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: ingress-nginx
+  namespace: argocd
+spec:
+  project: default
+  source:
+    repoURL: https://kubernetes.github.io/ingress-nginx
+    chart: ingress-nginx
+    targetRevision: 4.11.2
+    helm:
+      values: |
+        controller:
+          service:
+            type: LoadBalancer
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: ingress-nginx
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true

--- a/infra/argocd/app-prod.yaml
+++ b/infra/argocd/app-prod.yaml
@@ -1,0 +1,23 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: event-seat-booking-prod
+  namespace: argocd
+spec:
+  project: default
+  source:
+    repoURL: git@github.com:cyprus7/event-seat-booking.git
+    targetRevision: main
+    path: infra/charts/app
+    helm:
+      valueFiles:
+        - ../../envs/prod/values.yaml
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: prod
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true

--- a/infra/cert/cluster-issuer.yaml
+++ b/infra/cert/cluster-issuer.yaml
@@ -1,0 +1,14 @@
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: letsencrypt
+spec:
+  acme:
+    email: letsencrypt@mail.ru
+    server: https://acme-v02.api.letsencrypt.org/directory
+    privateKeySecretRef:
+      name: letsencrypt-account-key
+    solvers:
+      - http01:
+          ingress:
+            class: nginx

--- a/infra/charts/app/Chart.yaml
+++ b/infra/charts/app/Chart.yaml
@@ -1,0 +1,3 @@
+apiVersion: v2
+name: event-seat-booking
+version: 0.1.0

--- a/infra/charts/app/templates/_helpers.tpl
+++ b/infra/charts/app/templates/_helpers.tpl
@@ -1,0 +1,12 @@
+{{- define "event-seat-booking.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "event-seat-booking.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- printf "%s" $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}

--- a/infra/charts/app/templates/backend.yaml
+++ b/infra/charts/app/templates/backend.yaml
@@ -1,0 +1,72 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "event-seat-booking.fullname" . }}-backend
+  labels:
+    app.kubernetes.io/name: {{ include "event-seat-booking.name" . }}-backend
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/component: backend
+spec:
+  replicas: {{ .Values.backend.replicas }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ include "event-seat-booking.name" . }}-backend
+      app.kubernetes.io/instance: {{ .Release.Name }}
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: {{ include "event-seat-booking.name" . }}-backend
+        app.kubernetes.io/instance: {{ .Release.Name }}
+        app.kubernetes.io/component: backend
+    spec:
+      containers:
+        - name: backend
+          image: {{ printf "%s/backend:%s" .Values.image.repo .Values.image.tag }}
+          ports:
+            - containerPort: 3001
+          env:
+            - name: POSTGRES_URL
+              valueFrom:
+                secretKeyRef:
+                  name: app-secrets
+                  key: POSTGRES_URL
+            - name: REDIS_URL
+              valueFrom:
+                secretKeyRef:
+                  name: app-secrets
+                  key: REDIS_URL
+            - name: RABBITMQ_URL
+              valueFrom:
+                secretKeyRef:
+                  name: app-secrets
+                  key: RABBITMQ_URL
+            - name: BOT_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: app-secrets
+                  key: BOT_TOKEN
+            - name: JWT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: app-secrets
+                  key: JWT_SECRET
+{{- with .Values.backend.extraEnv }}
+{{ toYaml . | indent 12 }}
+{{- end }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "event-seat-booking.fullname" . }}-backend
+  labels:
+    app.kubernetes.io/name: {{ include "event-seat-booking.name" . }}-backend
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/component: backend
+spec:
+  selector:
+    app.kubernetes.io/name: {{ include "event-seat-booking.name" . }}-backend
+    app.kubernetes.io/instance: {{ .Release.Name }}
+  ports:
+    - name: http
+      port: 80
+      targetPort: 3001

--- a/infra/charts/app/templates/frontend.yaml
+++ b/infra/charts/app/templates/frontend.yaml
@@ -1,0 +1,46 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "event-seat-booking.fullname" . }}-frontend
+  labels:
+    app.kubernetes.io/name: {{ include "event-seat-booking.name" . }}-frontend
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/component: frontend
+spec:
+  replicas: {{ .Values.frontend.replicas }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ include "event-seat-booking.name" . }}-frontend
+      app.kubernetes.io/instance: {{ .Release.Name }}
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: {{ include "event-seat-booking.name" . }}-frontend
+        app.kubernetes.io/instance: {{ .Release.Name }}
+        app.kubernetes.io/component: frontend
+    spec:
+      containers:
+        - name: frontend
+          image: {{ printf "%s/frontend:%s" .Values.image.repo .Values.image.tag }}
+          ports:
+            - containerPort: 3000
+          env:
+            - name: NEXT_PUBLIC_API_URL
+              value: https://{{ .Values.host }}/api
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "event-seat-booking.fullname" . }}-frontend
+  labels:
+    app.kubernetes.io/name: {{ include "event-seat-booking.name" . }}-frontend
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/component: frontend
+spec:
+  selector:
+    app.kubernetes.io/name: {{ include "event-seat-booking.name" . }}-frontend
+    app.kubernetes.io/instance: {{ .Release.Name }}
+  ports:
+    - name: http
+      port: 80
+      targetPort: 3000

--- a/infra/charts/app/templates/ingress.yaml
+++ b/infra/charts/app/templates/ingress.yaml
@@ -1,0 +1,32 @@
+{{- if .Values.ingress.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "event-seat-booking.fullname" . }}
+  annotations:
+    cert-manager.io/cluster-issuer: letsencrypt
+spec:
+  ingressClassName: {{ .Values.ingress.className }}
+  tls:
+    - hosts:
+        - {{ .Values.host }}
+      secretName: tls-{{ .Values.host }}
+  rules:
+    - host: {{ .Values.host }}
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: {{ include "event-seat-booking.fullname" . }}-frontend
+                port:
+                  number: 80
+          - path: /api
+            pathType: Prefix
+            backend:
+              service:
+                name: {{ include "event-seat-booking.fullname" . }}-backend
+                port:
+                  number: 80
+{{- end }}

--- a/infra/charts/app/values.yaml
+++ b/infra/charts/app/values.yaml
@@ -1,0 +1,12 @@
+image:
+  repo: ghcr.io/cyprus7/event-seat-booking
+  tag: latest
+host: seats.test.chernov.us
+ingress:
+  enabled: true
+  className: nginx
+frontend:
+  replicas: 2
+backend:
+  replicas: 2
+  extraEnv: []

--- a/infra/envs/prod/values.yaml
+++ b/infra/envs/prod/values.yaml
@@ -1,0 +1,14 @@
+image:
+  repo: ghcr.io/cyprus7/event-seat-booking
+  tag: latest
+host: seats.test.chernov.us
+ingress:
+  enabled: true
+  className: nginx
+frontend:
+  replicas: 2
+backend:
+  replicas: 2
+  extraEnv:
+    - name: ENABLE_SWAGGER
+      value: "true"


### PR DESCRIPTION
## Summary
- add an application Helm chart with frontend, backend, and ingress templates
- provide prod environment values and a ClusterIssuer for TLS
- configure Argo CD applications for ingress-nginx, cert-manager, and the prod deployment

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68e3ef776e84832bac75353006d60c19