### PR TITLE
Split user and admin apps with SSE attendee updates

### DIFF
--- a/apps/backend/src/modules/bookings/bookings.controller.ts
+++ b/apps/backend/src/modules/bookings/bookings.controller.ts
@@ -5,9 +5,11 @@ import {
     Get,
     HttpCode,
     HttpStatus,
+    MessageEvent,
     Param,
     ParseIntPipe,
     Post,
+    Sse,
 } from '@nestjs/common'
 import { ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger'
 import { BookingsService } from './bookings.service'
@@ -15,6 +17,8 @@ import { CreateBookingDto } from './dto/create-booking.dto'
 import { ReserveBookingDto } from './dto/reserve-booking.dto'
 import { BookingsGatewayService } from './bookings.gateway.service'
 import { ReserveBookingResponseDto } from './dto/reserve-booking-response.dto'
+import { BookingsStreamService } from './bookings.stream.service'
+import { Observable } from 'rxjs'
 
 @ApiTags('bookings')
 @Controller('bookings')
@@ -22,6 +26,7 @@ export class BookingsController {
     constructor(
         private readonly bookingsService: BookingsService,
         private readonly bookingsGatewayService: BookingsGatewayService,
+        private readonly bookingsStreamService: BookingsStreamService,
     ) {}
 
     @Post()
@@ -68,6 +73,19 @@ export class BookingsController {
     @ApiResponse({ status: 200, description: 'Return bookings for event' })
     findByEvent(@Param('eventId', ParseIntPipe) eventId: number) {
         return this.bookingsService.findByEvent(eventId)
+    }
+
+    @Get('attendees')
+    @ApiOperation({ summary: 'Get attendees grouped by event' })
+    @ApiResponse({ status: 200, description: 'Return attendees grouped by event' })
+    findAttendees() {
+        return this.bookingsService.getEventAttendees()
+    }
+
+    @Sse('attendees/stream')
+    @ApiOperation({ summary: 'Stream attendees grouped by event' })
+    attendeesStream(): Observable<MessageEvent> {
+        return this.bookingsStreamService.stream
     }
 
     @Delete(':id')

--- a/apps/backend/src/modules/bookings/bookings.gateway.service.ts
+++ b/apps/backend/src/modules/bookings/bookings.gateway.service.ts
@@ -4,22 +4,30 @@ import { lastValueFrom } from 'rxjs'
 import { BOOKING_RESERVE_PATTERN, BOOKING_SERVICE_CLIENT } from './bookings.constants'
 import { BookingIdentifiersDto } from './dto/booking-identifiers.dto'
 import { ReserveBookingResponseDto } from './dto/reserve-booking-response.dto'
+import { BookingsStreamService } from './bookings.stream.service'
 
 @Injectable()
 export class BookingsGatewayService {
     constructor(
         @Inject(BOOKING_SERVICE_CLIENT)
         private readonly client: ClientProxy,
+        private readonly bookingsStreamService: BookingsStreamService,
     ) {}
 
     async reserve(dto: BookingIdentifiersDto): Promise<ReserveBookingResponseDto> {
         try {
-            return await lastValueFrom(
+            const response = await lastValueFrom(
                 this.client.send<ReserveBookingResponseDto, BookingIdentifiersDto>(
                     BOOKING_RESERVE_PATTERN,
                     dto,
                 ),
             )
+
+            if (response.wasCreated) {
+                await this.bookingsStreamService.broadcastAttendees()
+            }
+
+            return response
         } catch (error) {
             if (error instanceof RpcException) {
                 const rpcError = error.getError()

--- a/apps/backend/src/modules/bookings/bookings.module.ts
+++ b/apps/backend/src/modules/bookings/bookings.module.ts
@@ -9,6 +9,7 @@ import { BookingsQueueController } from './bookings.queue.controller'
 import { BookingsGatewayService } from './bookings.gateway.service'
 import { MetricsService } from '../../common/observability/metrics.service'
 import { BOOKING_SERVICE_CLIENT } from './bookings.constants'
+import { BookingsStreamService } from './bookings.stream.service'
 
 @Module({
     imports: [ConfigModule, TypeOrmModule.forFeature([Booking])],
@@ -17,6 +18,7 @@ import { BOOKING_SERVICE_CLIENT } from './bookings.constants'
         BookingsService,
         MetricsService,
         BookingsGatewayService,
+        BookingsStreamService,
         {
             provide: BOOKING_SERVICE_CLIENT,
             useFactory: (configService: ConfigService) =>

--- a/apps/backend/src/modules/bookings/bookings.stream.service.ts
+++ b/apps/backend/src/modules/bookings/bookings.stream.service.ts
@@ -1,0 +1,34 @@
+import { Injectable, Logger, OnModuleInit } from '@nestjs/common'
+import { ReplaySubject } from 'rxjs'
+import { map } from 'rxjs/operators'
+import { BookingsService } from './bookings.service'
+import { EventAttendeesDto } from './dto/event-attendees.dto'
+
+@Injectable()
+export class BookingsStreamService implements OnModuleInit {
+    private readonly logger = new Logger(BookingsStreamService.name)
+    private readonly attendees$ = new ReplaySubject<EventAttendeesDto[]>(1)
+
+    constructor(private readonly bookingsService: BookingsService) {}
+
+    async onModuleInit(): Promise<void> {
+        await this.broadcastAttendees()
+    }
+
+    get stream() {
+        return this.attendees$.pipe(map((data) => ({ data })))
+    }
+
+    async broadcastAttendees(): Promise<void> {
+        try {
+            const attendees = await this.bookingsService.getEventAttendees()
+            this.attendees$.next(attendees)
+        } catch (error) {
+            this.logger.error(
+                'Failed to broadcast attendees',
+                error instanceof Error ? error.stack : undefined,
+                error instanceof Error ? error.message : String(error),
+            )
+        }
+    }
+}

--- a/apps/backend/src/modules/bookings/dto/event-attendees.dto.ts
+++ b/apps/backend/src/modules/bookings/dto/event-attendees.dto.ts
@@ -1,0 +1,10 @@
+export interface BookingAttendeeDto {
+    userId: string
+    bookedAt: string
+}
+
+export interface EventAttendeesDto {
+    eventId: number
+    eventName: string
+    attendees: BookingAttendeeDto[]
+}

--- a/apps/backend/src/modules/events/events.controller.ts
+++ b/apps/backend/src/modules/events/events.controller.ts
@@ -3,6 +3,7 @@ import {
     Controller,
     Delete,
     Get,
+    Headers,
     HttpCode,
     HttpStatus,
     Param,
@@ -30,7 +31,11 @@ export class EventsController {
     @Get()
     @ApiOperation({ summary: 'Get all events' })
     @ApiResponse({ status: 200, description: 'Return all events' })
-    findAll() {
+    findAll(@Headers('x-user-id') userId?: string) {
+        const sanitizedUserId = userId?.trim()
+        if (sanitizedUserId) {
+            return this.eventsService.findAllWithUserStatus(sanitizedUserId)
+        }
         return this.eventsService.findAll()
     }
 

--- a/apps/backend/src/modules/events/events.module.ts
+++ b/apps/backend/src/modules/events/events.module.ts
@@ -3,9 +3,10 @@ import { TypeOrmModule } from '@nestjs/typeorm'
 import { EventsController } from './events.controller'
 import { EventsService } from './events.service'
 import { Event } from './entities/event.entity'
+import { Booking } from '../bookings/entities/booking.entity'
 
 @Module({
-    imports: [TypeOrmModule.forFeature([Event])],
+    imports: [TypeOrmModule.forFeature([Event, Booking])],
     controllers: [EventsController],
     providers: [EventsService],
     exports: [EventsService],

--- a/apps/frontend/src/app/admin/events/page.tsx
+++ b/apps/frontend/src/app/admin/events/page.tsx
@@ -1,114 +1,311 @@
-import Link from 'next/link'
-import { fetchAdminEvents } from '@/services/admin/events-service'
+'use client'
 
-export const metadata = {
-    title: 'Admin | Events',
+import { ChangeEvent, FormEvent, useCallback, useEffect, useState } from 'react'
+import Link from 'next/link'
+import {
+    AdminEvent,
+    CreateAdminEventPayload,
+    createAdminEvent,
+    fetchAdminEvents,
+} from '@/services/admin/events-service'
+import {
+    AdminEventAttendees,
+    fetchEventAttendees,
+    subscribeToEventAttendees,
+} from '@/services/admin/attendees-service'
+
+const initialFormState: CreateAdminEventPayload & { eventDate: string } = {
+    name: '',
+    description: '',
+    eventDate: '',
+    venue: '',
+    totalSeats: 0,
 }
 
-export default async function AdminEventsPage() {
-    let events: Awaited<ReturnType<typeof fetchAdminEvents>> = []
-    let error: string | null = null
+export default function AdminEventsPage() {
+    const [events, setEvents] = useState<AdminEvent[]>([])
+    const [attendees, setAttendees] = useState<AdminEventAttendees[]>([])
+    const [eventsLoading, setEventsLoading] = useState(false)
+    const [eventsError, setEventsError] = useState<string | null>(null)
+    const [attendeesError, setAttendeesError] = useState<string | null>(null)
+    const [formState, setFormState] = useState(initialFormState)
+    const [isSubmitting, setIsSubmitting] = useState(false)
+    const [formMessage, setFormMessage] = useState<string | null>(null)
 
-    try {
-        events = await fetchAdminEvents()
-    } catch (err) {
-        error = err instanceof Error ? err.message : 'Unexpected error while loading events'
+    const loadEvents = useCallback(async () => {
+        setEventsLoading(true)
+        setEventsError(null)
+        try {
+            const data = await fetchAdminEvents()
+            setEvents(data)
+        } catch (error) {
+            const message = error instanceof Error ? error.message : 'Failed to load events'
+            setEventsError(message)
+        } finally {
+            setEventsLoading(false)
+        }
+    }, [])
+
+    const loadAttendees = useCallback(async () => {
+        setAttendeesError(null)
+        try {
+            const data = await fetchEventAttendees()
+            setAttendees(data)
+        } catch (error) {
+            const message = error instanceof Error ? error.message : 'Failed to load attendees'
+            setAttendeesError(message)
+        }
+    }, [])
+
+    useEffect(() => {
+        void loadEvents()
+        void loadAttendees()
+        const unsubscribe = subscribeToEventAttendees((payload) => {
+            setAttendees(payload)
+        })
+        return () => unsubscribe()
+    }, [loadEvents, loadAttendees])
+
+    const handleChange =
+        (field: keyof CreateAdminEventPayload) =>
+        (event: ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
+            const value = field === 'totalSeats' ? Number(event.target.value) : event.target.value
+            setFormState((prev) => ({
+                ...prev,
+                [field]: value,
+            }))
+        }
+
+    const handleDateChange = (event: ChangeEvent<HTMLInputElement>) => {
+        setFormState((prev) => ({
+            ...prev,
+            eventDate: event.target.value,
+        }))
+    }
+
+    const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+        event.preventDefault()
+        setIsSubmitting(true)
+        setFormMessage(null)
+        try {
+            await createAdminEvent({
+                name: formState.name,
+                description: formState.description,
+                venue: formState.venue,
+                totalSeats: Number(formState.totalSeats),
+                eventDate: formState.eventDate
+                    ? new Date(formState.eventDate).toISOString()
+                    : new Date().toISOString(),
+            })
+            setFormMessage('Событие успешно создано')
+            setFormState(initialFormState)
+            await loadEvents()
+        } catch (error) {
+            const message = error instanceof Error ? error.message : 'Не удалось создать событие'
+            setFormMessage(message)
+        } finally {
+            setIsSubmitting(false)
+        }
     }
 
     return (
-        <main className="min-h-screen bg-gray-50 p-8">
+        <main className="min-h-screen bg-gray-50 p-6 sm:p-10">
             <div className="mx-auto flex max-w-5xl flex-col gap-6">
-                <div className="flex items-center justify-between">
+                <header className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
                     <div>
-                        <h1 className="text-3xl font-semibold text-gray-900">Admin Events</h1>
+                        <h1 className="text-3xl font-semibold text-gray-900">
+                            Администрирование мероприятий
+                        </h1>
                         <p className="text-sm text-gray-600">
-                            Review upcoming events and track seat utilization in real time.
+                            Управляйте мероприятиями и отслеживайте посетителей в режиме реального
+                            времени.
                         </p>
                     </div>
                     <Link
                         href="/"
-                        className="rounded-md bg-blue-600 px-4 py-2 text-sm font-medium text-white shadow hover:bg-blue-700"
+                        className="inline-flex items-center justify-center rounded-md border border-blue-600 px-4 py-2 text-sm font-medium text-blue-600 hover:bg-blue-50"
                     >
-                        Back to site
+                        Вернуться к пользователю
                     </Link>
-                </div>
+                </header>
 
-                {error ? (
-                    <div className="rounded-md border border-red-200 bg-red-50 p-4 text-sm text-red-700">
-                        {error}
+                <section className="rounded-lg bg-white p-4 shadow">
+                    <h2 className="text-lg font-semibold text-gray-900">Добавить событие</h2>
+                    <form onSubmit={handleSubmit} className="mt-4 grid gap-4 sm:grid-cols-2">
+                        <label className="flex flex-col gap-1 text-sm font-medium text-gray-700">
+                            Название
+                            <input
+                                value={formState.name}
+                                onChange={handleChange('name')}
+                                required
+                                className="rounded-md border border-gray-300 px-3 py-2 focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-200"
+                            />
+                        </label>
+                        <label className="flex flex-col gap-1 text-sm font-medium text-gray-700">
+                            Место проведения
+                            <input
+                                value={formState.venue}
+                                onChange={handleChange('venue')}
+                                required
+                                className="rounded-md border border-gray-300 px-3 py-2 focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-200"
+                            />
+                        </label>
+                        <label className="sm:col-span-2 flex flex-col gap-1 text-sm font-medium text-gray-700">
+                            Описание
+                            <textarea
+                                value={formState.description}
+                                onChange={(event) =>
+                                    setFormState((prev) => ({
+                                        ...prev,
+                                        description: event.target.value,
+                                    }))
+                                }
+                                required
+                                className="rounded-md border border-gray-300 px-3 py-2 focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-200"
+                            />
+                        </label>
+                        <label className="flex flex-col gap-1 text-sm font-medium text-gray-700">
+                            Дата и время
+                            <input
+                                type="datetime-local"
+                                value={formState.eventDate}
+                                onChange={handleDateChange}
+                                required
+                                className="rounded-md border border-gray-300 px-3 py-2 focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-200"
+                            />
+                        </label>
+                        <label className="flex flex-col gap-1 text-sm font-medium text-gray-700">
+                            Всего мест
+                            <input
+                                type="number"
+                                min={1}
+                                value={formState.totalSeats || ''}
+                                onChange={handleChange('totalSeats')}
+                                required
+                                className="rounded-md border border-gray-300 px-3 py-2 focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-200"
+                            />
+                        </label>
+                        <div className="sm:col-span-2 flex flex-col gap-2">
+                            <button
+                                type="submit"
+                                disabled={isSubmitting}
+                                className={`inline-flex w-full items-center justify-center rounded-md px-4 py-2 text-sm font-medium shadow ${
+                                    isSubmitting
+                                        ? 'cursor-not-allowed bg-gray-200 text-gray-500'
+                                        : 'bg-blue-600 text-white hover:bg-blue-700'
+                                }`}
+                            >
+                                {isSubmitting ? 'Создание...' : 'Создать событие'}
+                            </button>
+                            {formMessage && <p className="text-sm text-gray-600">{formMessage}</p>}
+                        </div>
+                    </form>
+                </section>
+
+                <section className="rounded-lg bg-white p-4 shadow">
+                    <div className="flex items-center justify-between">
+                        <h2 className="text-lg font-semibold text-gray-900">Список событий</h2>
+                        <button
+                            onClick={() => void loadEvents()}
+                            className="rounded-md border border-gray-300 px-3 py-1 text-xs font-medium text-gray-600 hover:bg-gray-50"
+                        >
+                            Обновить
+                        </button>
                     </div>
-                ) : (
-                    <div className="overflow-hidden rounded-lg border border-gray-200 bg-white shadow">
-                        <table className="min-w-full divide-y divide-gray-200">
-                            <thead className="bg-gray-100">
-                                <tr>
-                                    <th className="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wide text-gray-600">
-                                        Event
-                                    </th>
-                                    <th className="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wide text-gray-600">
-                                        Date
-                                    </th>
-                                    <th className="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wide text-gray-600">
-                                        Venue
-                                    </th>
-                                    <th className="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wide text-gray-600">
-                                        Seats
-                                    </th>
-                                    <th className="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wide text-gray-600">
-                                        Saturation
-                                    </th>
-                                </tr>
-                            </thead>
-                            <tbody className="divide-y divide-gray-200">
-                                {events.map((event) => {
-                                    const eventDate = new Date(event.eventDate)
-                                    const saturation = event.totalSeats
-                                        ? Math.round(
-                                              ((event.totalSeats - event.availableSeats) /
-                                                  event.totalSeats) *
-                                                  100,
-                                          )
-                                        : 0
-
-                                    return (
-                                        <tr key={event.id} className="hover:bg-gray-50">
-                                            <td className="px-4 py-3 text-sm text-gray-900">
-                                                <div className="font-medium">{event.name}</div>
-                                                <div className="text-xs text-gray-500">
-                                                    {event.description}
-                                                </div>
-                                            </td>
-                                            <td className="px-4 py-3 text-sm text-gray-700">
-                                                {eventDate.toLocaleString()}
-                                            </td>
-                                            <td className="px-4 py-3 text-sm text-gray-700">
-                                                {event.venue}
-                                            </td>
-                                            <td className="px-4 py-3 text-sm text-gray-700">
-                                                {event.totalSeats - event.availableSeats} /{' '}
-                                                {event.totalSeats}
-                                            </td>
-                                            <td className="px-4 py-3 text-sm font-semibold text-blue-600">
-                                                {saturation}%
-                                            </td>
-                                        </tr>
-                                    )
-                                })}
-
-                                {events.length === 0 && !error && (
+                    {eventsLoading ? (
+                        <p className="mt-4 text-sm text-gray-600">Загрузка событий...</p>
+                    ) : eventsError ? (
+                        <p className="mt-4 text-sm text-red-600">{eventsError}</p>
+                    ) : events.length === 0 ? (
+                        <p className="mt-4 text-sm text-gray-600">События не найдены</p>
+                    ) : (
+                        <div className="mt-4 overflow-hidden rounded-lg border border-gray-200">
+                            <table className="min-w-full divide-y divide-gray-200">
+                                <thead className="bg-gray-100">
                                     <tr>
-                                        <td
-                                            colSpan={5}
-                                            className="px-4 py-6 text-center text-sm text-gray-600"
-                                        >
-                                            No events found.
-                                        </td>
+                                        <th className="px-4 py-2 text-left text-xs font-semibold uppercase tracking-wide text-gray-600">
+                                            Событие
+                                        </th>
+                                        <th className="px-4 py-2 text-left text-xs font-semibold uppercase tracking-wide text-gray-600">
+                                            Дата
+                                        </th>
+                                        <th className="px-4 py-2 text-left text-xs font-semibold uppercase tracking-wide text-gray-600">
+                                            Площадка
+                                        </th>
+                                        <th className="px-4 py-2 text-left text-xs font-semibold uppercase tracking-wide text-gray-600">
+                                            Занято / Всего
+                                        </th>
                                     </tr>
-                                )}
-                            </tbody>
-                        </table>
-                    </div>
-                )}
+                                </thead>
+                                <tbody className="divide-y divide-gray-200">
+                                    {events.map((event) => {
+                                        const eventDate = new Date(event.eventDate)
+                                        return (
+                                            <tr key={event.id} className="hover:bg-gray-50">
+                                                <td className="px-4 py-3 text-sm text-gray-900">
+                                                    <div className="font-medium">{event.name}</div>
+                                                    <div className="text-xs text-gray-500">
+                                                        {event.description}
+                                                    </div>
+                                                </td>
+                                                <td className="px-4 py-3 text-sm text-gray-700">
+                                                    {eventDate.toLocaleString()}
+                                                </td>
+                                                <td className="px-4 py-3 text-sm text-gray-700">
+                                                    {event.venue}
+                                                </td>
+                                                <td className="px-4 py-3 text-sm text-gray-700">
+                                                    {event.totalSeats - event.availableSeats} /{' '}
+                                                    {event.totalSeats}
+                                                </td>
+                                            </tr>
+                                        )
+                                    })}
+                                </tbody>
+                            </table>
+                        </div>
+                    )}
+                </section>
+
+                <section className="rounded-lg bg-white p-4 shadow">
+                    <h2 className="text-lg font-semibold text-gray-900">Посетители</h2>
+                    {attendeesError && (
+                        <p className="mt-3 text-sm text-red-600">{attendeesError}</p>
+                    )}
+                    {attendees.length === 0 ? (
+                        <p className="mt-3 text-sm text-gray-600">
+                            Пока нет зарегистрированных пользователей
+                        </p>
+                    ) : (
+                        <div className="mt-3 space-y-4">
+                            {attendees.map((group) => (
+                                <div
+                                    key={group.eventId}
+                                    className="rounded-md border border-gray-200 p-4"
+                                >
+                                    <h3 className="text-md font-semibold text-gray-900">
+                                        {group.eventName}
+                                    </h3>
+                                    <ul className="mt-2 space-y-1 text-sm text-gray-700">
+                                        {group.attendees.map((attendee) => {
+                                            const bookedAt = new Date(attendee.bookedAt)
+                                            return (
+                                                <li
+                                                    key={`${group.eventId}-${attendee.userId}-${attendee.bookedAt}`}
+                                                >
+                                                    <span className="font-medium">
+                                                        {attendee.userId}
+                                                    </span>{' '}
+                                                    — {bookedAt.toLocaleString()}
+                                                </li>
+                                            )
+                                        })}
+                                    </ul>
+                                </div>
+                            ))}
+                        </div>
+                    )}
+                </section>
             </div>
         </main>
     )

--- a/apps/frontend/src/app/page.tsx
+++ b/apps/frontend/src/app/page.tsx
@@ -1,24 +1,213 @@
+'use client'
+
+import { FormEvent, useCallback, useEffect, useMemo, useState } from 'react'
 import Link from 'next/link'
+import { fetchEventsForUser, reserveEvent, UserEvent } from '@/services/events-service'
+
+function detectDefaultUserId(): string {
+    if (typeof window === 'undefined') {
+        return ''
+    }
+
+    const navigatorInfo = window.navigator as Navigator & { userAgentData?: { platform?: string } }
+    const candidate =
+        navigatorInfo.userAgentData?.platform ||
+        navigatorInfo.platform ||
+        navigatorInfo.userAgent ||
+        ''
+
+    return candidate.replace(/\s+/g, '-').toLowerCase()
+}
 
 export default function HomePage() {
+    const [userIdInput, setUserIdInput] = useState('')
+    const [activeUserId, setActiveUserId] = useState('')
+    const [events, setEvents] = useState<UserEvent[]>([])
+    const [loadingEvents, setLoadingEvents] = useState(false)
+    const [bookingEventId, setBookingEventId] = useState<number | null>(null)
+    const [error, setError] = useState<string | null>(null)
+    const [message, setMessage] = useState<string | null>(null)
+
+    useEffect(() => {
+        const defaultId = detectDefaultUserId()
+        setUserIdInput(defaultId)
+        setActiveUserId(defaultId)
+    }, [])
+
+    const loadEvents = useCallback(async (userId: string) => {
+        if (!userId) {
+            setEvents([])
+            return
+        }
+
+        setLoadingEvents(true)
+        setError(null)
+        try {
+            const data = await fetchEventsForUser(userId)
+            setEvents(data)
+        } catch (err) {
+            const message = err instanceof Error ? err.message : 'Неизвестная ошибка'
+            setError(message)
+        } finally {
+            setLoadingEvents(false)
+        }
+    }, [])
+
+    useEffect(() => {
+        void loadEvents(activeUserId)
+    }, [activeUserId, loadEvents])
+
+    const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
+        event.preventDefault()
+        const trimmed = userIdInput.trim()
+        setActiveUserId(trimmed)
+        setMessage(null)
+    }
+
+    const handleReserve = async (eventId: number) => {
+        if (!activeUserId) {
+            setError('Введите идентификатор пользователя')
+            return
+        }
+
+        setBookingEventId(eventId)
+        setError(null)
+        setMessage(null)
+        try {
+            const response = await reserveEvent(eventId, activeUserId)
+            if (response.wasCreated) {
+                setMessage('Бронирование подтверждено')
+            } else {
+                setMessage('Вы уже зарегистрированы на это мероприятие')
+            }
+            await loadEvents(activeUserId)
+        } catch (err) {
+            const message = err instanceof Error ? err.message : 'Не удалось забронировать место'
+            setError(message)
+        } finally {
+            setBookingEventId(null)
+        }
+    }
+
+    const userIdLabel = useMemo(() => activeUserId || '—', [activeUserId])
+
     return (
-        <main className="min-h-screen bg-gray-50 p-8">
-            <div className="mx-auto max-w-5xl space-y-6">
-                <div>
-                    <h1 className="text-4xl font-bold text-gray-900">Event Seat Booking</h1>
-                    <p className="mt-2 text-lg text-gray-600">
-                        Welcome to the event seat booking system. Browse events, reserve seats, and
-                        monitor utilization through the admin console.
+        <main className="min-h-screen bg-gray-50 p-6 sm:p-10">
+            <div className="mx-auto flex max-w-4xl flex-col gap-6">
+                <header className="flex flex-col gap-2">
+                    <h1 className="text-3xl font-bold text-gray-900">Бронирование мероприятий</h1>
+                    <p className="text-sm text-gray-600">
+                        Укажите идентификатор пользователя, чтобы проверить доступные мероприятия и
+                        забронировать места. Текущий идентификатор:{' '}
+                        <span className="font-semibold">{userIdLabel}</span>
                     </p>
-                </div>
-                <div className="flex flex-wrap gap-4">
-                    <Link
-                        href="/admin/events"
-                        className="inline-flex items-center rounded-md bg-blue-600 px-5 py-3 text-sm font-medium text-white shadow hover:bg-blue-700"
+                </header>
+
+                <section className="rounded-lg bg-white p-4 shadow">
+                    <form
+                        onSubmit={handleSubmit}
+                        className="flex flex-col gap-3 sm:flex-row sm:items-end"
                     >
-                        Go to admin events
-                    </Link>
-                </div>
+                        <label className="flex flex-col gap-1 text-sm font-medium text-gray-700 sm:flex-1">
+                            Идентификатор пользователя
+                            <input
+                                value={userIdInput}
+                                onChange={(event) => setUserIdInput(event.target.value)}
+                                className="w-full rounded-md border border-gray-300 px-3 py-2 text-base shadow-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-200"
+                                placeholder="например, workstation-01"
+                            />
+                        </label>
+                        <button
+                            type="submit"
+                            className="inline-flex items-center justify-center rounded-md bg-blue-600 px-4 py-2 text-sm font-medium text-white shadow hover:bg-blue-700"
+                        >
+                            Обновить список
+                        </button>
+                        <Link
+                            href="/admin/events"
+                            className="inline-flex items-center justify-center rounded-md border border-blue-600 px-4 py-2 text-sm font-medium text-blue-600 hover:bg-blue-50"
+                        >
+                            Панель администратора
+                        </Link>
+                    </form>
+                </section>
+
+                {message && (
+                    <div className="rounded-md border border-green-200 bg-green-50 p-3 text-sm text-green-700">
+                        {message}
+                    </div>
+                )}
+
+                {error && (
+                    <div className="rounded-md border border-red-200 bg-red-50 p-3 text-sm text-red-700">
+                        {error}
+                    </div>
+                )}
+
+                <section className="rounded-lg bg-white p-4 shadow">
+                    <h2 className="text-lg font-semibold text-gray-900">Доступные мероприятия</h2>
+                    {loadingEvents ? (
+                        <p className="mt-4 text-sm text-gray-600">Загрузка мероприятий...</p>
+                    ) : events.length === 0 ? (
+                        <p className="mt-4 text-sm text-gray-600">Мероприятия не найдены</p>
+                    ) : (
+                        <ul className="mt-4 space-y-4">
+                            {events.map((event) => {
+                                const eventDate = new Date(event.eventDate)
+                                const isDisabled =
+                                    event.alreadyBooked || bookingEventId === event.id
+                                return (
+                                    <li
+                                        key={event.id}
+                                        className="rounded-md border border-gray-200 p-4 shadow-sm"
+                                    >
+                                        <div className="flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
+                                            <div>
+                                                <h3 className="text-xl font-semibold text-gray-900">
+                                                    {event.name}
+                                                </h3>
+                                                <p className="text-sm text-gray-600">
+                                                    {event.description}
+                                                </p>
+                                                <dl className="mt-3 space-y-1 text-sm text-gray-700">
+                                                    <div className="flex gap-1">
+                                                        <dt className="font-medium">Дата:</dt>
+                                                        <dd>{eventDate.toLocaleString()}</dd>
+                                                    </div>
+                                                    <div className="flex gap-1">
+                                                        <dt className="font-medium">Место:</dt>
+                                                        <dd>{event.venue}</dd>
+                                                    </div>
+                                                    <div className="flex gap-1">
+                                                        <dt className="font-medium">
+                                                            Свободно мест:
+                                                        </dt>
+                                                        <dd>{event.availableSeats}</dd>
+                                                    </div>
+                                                </dl>
+                                            </div>
+                                            <button
+                                                onClick={() => handleReserve(event.id)}
+                                                disabled={isDisabled}
+                                                className={`mt-3 inline-flex items-center justify-center rounded-md px-4 py-2 text-sm font-medium shadow sm:mt-0 ${
+                                                    isDisabled
+                                                        ? 'cursor-not-allowed bg-gray-200 text-gray-500'
+                                                        : 'bg-blue-600 text-white hover:bg-blue-700'
+                                                }`}
+                                            >
+                                                {event.alreadyBooked
+                                                    ? 'Уже забронировано'
+                                                    : bookingEventId === event.id
+                                                      ? 'Обработка...'
+                                                      : 'Забронировать'}
+                                            </button>
+                                        </div>
+                                    </li>
+                                )
+                            })}
+                        </ul>
+                    )}
+                </section>
             </div>
         </main>
     )

--- a/apps/frontend/src/services/admin/attendees-service.ts
+++ b/apps/frontend/src/services/admin/attendees-service.ts
@@ -1,0 +1,45 @@
+const API_URL = process.env.NEXT_PUBLIC_API_URL ?? 'http://localhost:3001/api'
+
+export interface AdminAttendee {
+    userId: string
+    bookedAt: string
+}
+
+export interface AdminEventAttendees {
+    eventId: number
+    eventName: string
+    attendees: AdminAttendee[]
+}
+
+export async function fetchEventAttendees(): Promise<AdminEventAttendees[]> {
+    const response = await fetch(`${API_URL}/bookings/attendees`, { cache: 'no-store' })
+
+    if (!response.ok) {
+        throw new Error('Failed to load attendees')
+    }
+
+    return (await response.json()) as AdminEventAttendees[]
+}
+
+export function subscribeToEventAttendees(
+    onMessage: (payload: AdminEventAttendees[]) => void,
+): () => void {
+    const eventSource = new EventSource(`${API_URL}/bookings/attendees/stream`)
+
+    eventSource.onmessage = (event) => {
+        try {
+            const data = JSON.parse(event.data) as AdminEventAttendees[]
+            onMessage(data)
+        } catch (error) {
+            console.error('Failed to parse attendees event', error)
+        }
+    }
+
+    eventSource.onerror = (error) => {
+        console.error('Attendees stream error', error)
+    }
+
+    return () => {
+        eventSource.close()
+    }
+}

--- a/apps/frontend/src/services/admin/events-service.ts
+++ b/apps/frontend/src/services/admin/events-service.ts
@@ -1,5 +1,3 @@
-import 'server-only'
-
 type AdminEventResponse = {
     id: number
     name: string
@@ -18,7 +16,7 @@ const API_URL = process.env.NEXT_PUBLIC_API_URL ?? 'http://localhost:3001/api'
 
 export async function fetchAdminEvents(): Promise<AdminEvent[]> {
     const response = await fetch(`${API_URL}/events`, {
-        next: { revalidate: 15 },
+        cache: 'no-store',
     })
 
     if (!response.ok) {
@@ -30,4 +28,27 @@ export async function fetchAdminEvents(): Promise<AdminEvent[]> {
         ...event,
         availableSeats: Math.max(event.totalSeats - event.bookedSeats, 0),
     }))
+}
+
+export interface CreateAdminEventPayload {
+    name: string
+    description: string
+    eventDate: string
+    venue: string
+    totalSeats: number
+}
+
+export async function createAdminEvent(payload: CreateAdminEventPayload): Promise<void> {
+    const response = await fetch(`${API_URL}/events`, {
+        method: 'POST',
+        headers: {
+            'Content-Type': 'application/json',
+        },
+        body: JSON.stringify(payload),
+    })
+
+    if (!response.ok) {
+        const message = await response.text()
+        throw new Error(message || 'Failed to create event')
+    }
 }

--- a/apps/frontend/src/services/events-service.ts
+++ b/apps/frontend/src/services/events-service.ts
@@ -1,0 +1,54 @@
+const API_URL = process.env.NEXT_PUBLIC_API_URL ?? 'http://localhost:3001/api'
+
+export interface UserEvent {
+    id: number
+    name: string
+    description: string
+    eventDate: string
+    venue: string
+    totalSeats: number
+    bookedSeats: number
+    availableSeats: number
+    alreadyBooked: boolean
+}
+
+export interface ReserveEventResponse {
+    bookingId: number
+    eventId: number
+    userId: string
+    seatsRemaining: number
+    totalSeats: number
+    wasCreated: boolean
+}
+
+export async function fetchEventsForUser(userId: string): Promise<UserEvent[]> {
+    const response = await fetch(`${API_URL}/events`, {
+        headers: {
+            'x-user-id': userId,
+        },
+        cache: 'no-store',
+    })
+
+    if (!response.ok) {
+        throw new Error('Не удалось загрузить мероприятия')
+    }
+
+    return (await response.json()) as UserEvent[]
+}
+
+export async function reserveEvent(eventId: number, userId: string): Promise<ReserveEventResponse> {
+    const response = await fetch(`${API_URL}/bookings/reserve`, {
+        method: 'POST',
+        headers: {
+            'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({ eventId, userId }),
+    })
+
+    if (!response.ok) {
+        const message = await response.text()
+        throw new Error(message || 'Не удалось забронировать место')
+    }
+
+    return (await response.json()) as ReserveEventResponse
+}


### PR DESCRIPTION
## Summary
- add user-aware event APIs that flag existing bookings and broadcast attendee updates via SSE
- build a simplified end-user booking screen with per-user status and booking actions
- enhance the admin console with event creation tools and live attendee lists powered by SSE

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e59acb2bb8832bbbde8366885c6d9d